### PR TITLE
Disable HTTP.js timeouts

### DIFF
--- a/Server.js
+++ b/Server.js
@@ -37,6 +37,8 @@ app.use(multer()); // for parsing multipart/form-data
 
 app.post('/run', function (req, res) {
     res.status = 500;
+    req.socket.setTimeout(0);
+    res.socket.setTimeout(0);
     var input = req.body.input;
     if (input){
         algo_run.run(input, function (result){


### PR DESCRIPTION
The HTTP.js sockets created by Node.js have a default timeout of 120s. As a result, a POST request to `/run` will die if the algorithm takes longer than this to execute. The attached patch disables the timeout and resolves #29.
