### PR TITLE
Use streaming to return file results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-FROM ubuntu:14.04
+FROM ubuntu:15.10
 MAINTAINER Abdelrahman H. Ibrahim <abdelrahman.hosny@hotmail.com>
 RUN apt-get update && \
 apt-get install -y nodejs && \

--- a/Server.js
+++ b/Server.js
@@ -48,18 +48,18 @@ app.post('/v1/run', function (req, res) {
     var data_input = req.body.input;
     var file_input = req.files.input;
     if (data_input){
-        algo_run.run(data_input, function (result){
+        algo_run.run(data_input, function (result_stream){
             res.status = 200;
-            res.send(result);
-        });        
+            result_stream.pipe(res);
+        });
     } else if(file_input){
         fs.readFile(req.files.input.path, function (err, data) {
             var newPath = process.env.CODE_HOME + '/src/input.txt';
             fs.writeFile(newPath, data, function (err) {
-                algo_run.run(false, function (result){
+                algo_run.run(false, function (result_stream){
                     res.status = 200;
-                    res.send(result);
-                }); 
+                    result_stream.pipe(res);
+                });
             });
         });
     } else {

--- a/Server.js
+++ b/Server.js
@@ -31,8 +31,8 @@ fs.readFile(manifestFilePath, {encoding: 'utf-8'}, function(err,data){
     }
 });
 
-app.use(bodyParser.json({limit: '100mb'}));
-app.use(bodyParser.urlencoded({limit: '100mb', extended: true}));
+app.use(bodyParser.json({limit: '1000mb'}));
+app.use(bodyParser.urlencoded({limit: '1000mb', extended: true}));
 app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
 app.use(multer()); // for parsing multipart/form-data
 

--- a/Server.js
+++ b/Server.js
@@ -45,12 +45,23 @@ app.post('/v1/run', function (req, res) {
     res.status = 500;
     req.socket.setTimeout(0);
     res.socket.setTimeout(0);
-    var input = req.body.input;
-    if (input){
-        algo_run.run(input, function (result){
+    var data_input = req.body.input;
+    var file_input = req.files.input;
+    if (data_input){
+        algo_run.run(data_input, function (result){
             res.status = 200;
             res.send(result);
         });        
+    } else if(file_input){
+        fs.readFile(req.files.input.path, function (err, data) {
+            var newPath = process.env.CODE_HOME + '/src/input.txt';
+            fs.writeFile(newPath, data, function (err) {
+                algo_run.run(false, function (result){
+                    res.status = 200;
+                    res.send(result);
+                }); 
+            });
+        });
     } else {
         res.status = 200;
         res.send('No input provided!');

--- a/Server.js
+++ b/Server.js
@@ -7,12 +7,6 @@ var algo_run = require(path.join(__dirname, "/lib/Algo"));
 var strip_json = require(path.join(__dirname, "/lib/strip-json-comments"));
 var app = express();
 
-function haltOnTimedout(req, res, next){
-  if (!req.timedout) {
-      next();
-  }
-}
-
 // configure environment variables
 var manifestFilePath = path.join(__dirname, '/web/algorun_info/manifest.json');
 
@@ -42,7 +36,10 @@ app.use(bodyParser.urlencoded({limit: '100mb', extended: true}));
 app.use(bodyParser.urlencoded({ extended: true })); // for parsing application/x-www-form-urlencoded
 app.use(multer()); // for parsing multipart/form-data
 
+var last_used = 'never';
+
 app.post('/v1/run', function (req, res) {
+    last_used = new Date();
     res.header("Access-Control-Allow-Origin", "*");
     res.header("Access-Control-Allow-Headers", "X-Requested-With");
     res.status = 500;
@@ -87,6 +84,12 @@ app.get('/v1/manifest', function (req, res) {
     res.header("Access-Control-Allow-Headers", "X-Requested-With");
     res.status = 200;
     res.sendFile(manifestFilePath);
+});
+app.get('/v1/status', function (req, res) {
+    res.header("Access-Control-Allow-Origin", "*");
+    res.header("Access-Control-Allow-Headers", "X-Requested-With");
+    res.status = 200;
+    res.send({'last_used': last_used});
 });
 
 app.use(express.static(__dirname + '/web'));

--- a/lib/Algo.js
+++ b/lib/Algo.js
@@ -11,21 +11,21 @@ module.exports = {
         } else {
             callback("Are you sure you defined algo_exec?");
         }
-        
+
         process.chdir(process.env.CODE_HOME + '/src/');
         input_file = 'input.txt';
         if(input_data != false){
-            fs.writeFileSync(input_file, input_data);   
+            fs.writeFileSync(input_file, input_data);
         }
-        
+
         if (process.env.algo_output_filename) {
             output_file = process.env.algo_output_filename;
             output_file = output_file.trim();
             algo_command = command + ' ' + input_file;
             exec(algo_command, function (err, stdout, stderr) {
                 if (!err){
-                    result = fs.readFileSync(output_file, 'utf8');
-                    callback(result);
+                    var result_stream = fs.createReadStream(output_file);
+                    callback(result_stream);
                 } else {
                     callback('ERROR: Cannot run the algorithm! ' + stderr);
                 }

--- a/lib/Algo.js
+++ b/lib/Algo.js
@@ -14,7 +14,9 @@ module.exports = {
         
         process.chdir(process.env.CODE_HOME + '/src/');
         input_file = 'input.txt';
-        fs.writeFileSync(input_file, input_data);
+        if(input_data != false){
+            fs.writeFileSync(input_file, input_data);   
+        }
         
         if (process.env.algo_output_filename) {
             output_file = process.env.algo_output_filename;


### PR DESCRIPTION
The current design of the Algorun server loads the output file into memory before returning it. This can cause crashes when the output file is very large. This patch uses streaming to pipe the file into the response, avoiding the need to load the file.
